### PR TITLE
change app name

### DIFF
--- a/.electron-builder.config.js
+++ b/.electron-builder.config.js
@@ -3,8 +3,8 @@
  * @see https://www.electron.build/configuration/configuration
  */
 const config = {
-  appId: 'com.lucasstettner.typescape',
-  productName: 'Typescape',
+  appId: 'com.lucasstettner.fontastique',
+  productName: 'Fontastique',
   directories: {
     output: 'dist',
     buildResources: 'buildResources',
@@ -26,7 +26,7 @@ const config = {
     {
       provider: 'github',
       owner: 'lucas8',
-      repo: 'typescape',
+      repo: 'fontastique',
     },
   ],
 };

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 <p align="center">
-  <h3 align="center">Typescape</h3>
+  <h3 align="center">Fontastique</h3>
   <p align="center"><i>A font browser built for designers</i></p>
-  <p align="center">Mac (OSX): <a href="https://github.com/lucas8/typescape/releases/latest">Download</a></p>
+  <p align="center">Mac (OSX): <a href="https://github.com/lucas8/fontastique/releases/latest">Download</a></p>
   <p align="center">
     <img src="/assets/screenshot.png" alt="App screenshot" title="App screenshot">
   </p>
 </p>
 
 ## Planned Features:
+
 - [x] Browse system fonts
 - [x] Auto update (OSX)
 - [x] Theming
@@ -18,11 +19,13 @@
 - [ ] Allow copy/paste functions (add native menu bar controls)
 
 ## Notable Folders:
+
 - `/packages/renderer` - this is where all of the react client code is stored (mobx models, components, etc)
 - `/pacakges/main` - this module is responsible for creating the main window and setting up all the system defaults, also handles IPC requests
 - `/pacakges/preload` - this is a script that is exposed to the client for the purpose of communicating with the main process
 
 ## Contributing
+
 Feel free to make a PR and request a review!
 
 Deploys happen on my local machine but I'm happy to add your PR to the next release.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The font browser built for designers.",
   "private": true,
   "main": "packages/main/dist/index.cjs",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": {
     "email": "lucas.stettner@gmail.com",
     "name": "Lucas Stettner"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescape",
+  "name": "fontastique",
   "description": "The font browser built for designers.",
   "private": true,
   "main": "packages/main/dist/index.cjs",

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -10,7 +10,7 @@ async function createWindow() {
     height: 540,
     titleBarStyle: 'customButtonsOnHover',
     backgroundColor: '#DFD0BF',
-    title: 'Typescape',
+    title: 'Fontastique',
     hasShadow: true,
     webPreferences: {
       nodeIntegration: false,

--- a/packages/main/src/utils/getMenuTemplate.ts
+++ b/packages/main/src/utils/getMenuTemplate.ts
@@ -10,7 +10,7 @@ export const getMenuTemplate = (): MenuItemConstructorOptions[] => {
       label: name,
       submenu: [
         {
-          label: 'About Typescape',
+          label: 'About Fontastique',
           role: 'about',
         },
         {

--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta content="script-src 'self' blob:" http-equiv="Content-Security-Policy">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-  <title>Typescape</title>
+  <title>Fontastique</title>
 </head>
 
 <body>

--- a/packages/renderer/src/components/FontWeight/FontWeight.tsx
+++ b/packages/renderer/src/components/FontWeight/FontWeight.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
 import { FontWeight as FontWeightModel } from '~/models';
-import { Box, Tag, Text } from '~/components';
+import { Box, Tag } from '~/components';
 import { vars } from '~/styles';
 import * as styles from './styles.css';
 import { getFontWeightName } from '~/utils';
@@ -24,18 +24,16 @@ export const FontWeight = observer<FontWeightProps>(({ fontWeight }) => {
         )}
       </Box>
       <Box paddingX="4">
-        <Text
-          contentEditable
-          size="heading"
-          className={styles.contentEditable}
+        <input
+          type="text"
+          className={styles.fontWeightPreviewInput}
           style={{
-            fontSize: '24px',
             fontWeight: fontWeight.weight,
             fontFamily: `${fontWeight.postscriptName}, ${vars.fonts.body}`,
           }}
-        >
-          {fontWeight.font?.previewText}
-        </Text>
+          onChange={e => fontWeight.font?.updatePreviewText(e.target.value)}
+          value={fontWeight.font?.previewText}
+        />
       </Box>
     </Box>
   );

--- a/packages/renderer/src/components/FontWeight/FontWeight.tsx
+++ b/packages/renderer/src/components/FontWeight/FontWeight.tsx
@@ -19,7 +19,7 @@ export const FontWeight = observer<FontWeightProps>(({ fontWeight }) => {
         <FontName fontWeight={fontWeight} />
         {fontWeight.italic && (
           <i>
-            <Tag>itallic</Tag>
+            <Tag>italic</Tag>
           </i>
         )}
       </Box>

--- a/packages/renderer/src/components/FontWeight/styles.css.ts
+++ b/packages/renderer/src/components/FontWeight/styles.css.ts
@@ -1,4 +1,3 @@
-import { style } from '@vanilla-extract/css';
 import { sprinkles } from '~/styles';
 
 export const headerContainer = sprinkles({
@@ -14,10 +13,10 @@ export const headerContainer = sprinkles({
   overflow: 'hidden',
 });
 
-export const contentEditable = style({
-  selectors: {
-    '&:focus-visible': {
-      outline: 'none',
-    },
-  },
+export const fontWeightPreviewInput = sprinkles({
+  width: 'full',
+  fontSize: 'heading',
+  background: 'transparent',
+  borderWidth: '0',
+  outline: 'none',
 });

--- a/packages/renderer/src/components/ui/Text/Text.tsx
+++ b/packages/renderer/src/components/ui/Text/Text.tsx
@@ -22,6 +22,7 @@ type TextProps = {
   height?: BoxProps['height'];
   className?: BoxProps['className'];
   contentEditable?: BoxProps['contentEditable'];
+  onChange?: BoxProps['onChange'];
 } & styles.Variants;
 
 export const Text = forwardRef(

--- a/packages/renderer/src/models/Font.ts
+++ b/packages/renderer/src/models/Font.ts
@@ -30,7 +30,7 @@ export class Font extends Model<FontStore> {
   @computed
   public get sortedWeights() {
     return this.weights.sort((a, b) => {
-      // sorted by weight, itallic at the bottom
+      // sorted by weight, italic at the bottom
       return a.weight + (a.italic ? 1 : 0) - (b.weight + (b.italic ? 1 : 0));
     });
   }

--- a/packages/renderer/src/models/Font.ts
+++ b/packages/renderer/src/models/Font.ts
@@ -8,6 +8,7 @@ export class Font extends Model<FontStore> {
   @observable
   public name = '';
 
+  @observable
   public previewText = 'How vexingly quick daft zebras jump!';
 
   constructor(store: FontStore, fields: Partial<Font> = {}) {
@@ -15,6 +16,11 @@ export class Font extends Model<FontStore> {
     makeObservable(this);
 
     set(this, fields);
+  }
+
+  @action.bound
+  public updatePreviewText(nextPreviewText: string) {
+    this.previewText = nextPreviewText;
   }
 
   @action.bound

--- a/packages/renderer/src/styles/sprinkles.css.ts
+++ b/packages/renderer/src/styles/sprinkles.css.ts
@@ -110,6 +110,7 @@ const selectorProperties = defineProperties({
     background: vars.colors,
     borderColor: vars.colors,
     color: vars.colors,
+    outline: ['none', 'auto'],
     outlineColor: vars.colors,
   },
 });

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -10,7 +10,7 @@ module.exports = async function (context) {
   }
 
   // Same appId in electron-builder.
-  const appId = 'com.lucasstettner.typescape';
+  const appId = 'com.lucasstettner.fontastique';
 
   const appPath = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`);
   if (!fs.existsSync(appPath)) {


### PR DESCRIPTION
- fix compile
- add title animation
- add basic font card
- virtualized list component
- add virtualized scrolling
- fix card scroll align
- overscan more items
- polish
- cleaup animation
- see more styles
- overly polish title changes
- fix asset folder
- scrolling interaction
- fix build step
- small fixes
- change window name
- change font provider
- fix top bar scroller
- clean up content
- fix lint
- only target mac-os
- add property and onetoone metadata reflection & db mirroring
- change on-to-one to many-to-one
- progress on incremental hydration
- cleaup
- switch to swc
- fix lint
- change apis
- update latest designs
- remove overengineered latent model injection
- remove idb
- fresh start
- set up sprinkles better
- implement list and preview components
- style tweaks
- setup new component
- back to esbuild
- add text component
- add basic weight preivew
- add basic size slider
- cleanup
- style tweaks
- new weight designs
- interaction changes and tweaks
- change preview
- builder changes
- fix window controls
- bump version
- add auto-updater & fix traffic lights
- bump version
- test auto-updating
- fix electron builder public config
- remove gatekeeper
- test auto update
- add auto updater logging
- bump version
- add better logging and service
- autoupdater test
- dynamic import autoupdater & change mac target
- version bump
- another autoupdater test
- notarize properly
- remove plist
- update icon
- final test
- fix code signing
- bump
- remove menu options
- fix noterize script
- remove autoupdater logs
- add mit licence
- add fonts with licences
- add backup fonts
- bump back version to 1.0.0
- Update README.md
- fix fonts and window controls
- bump version & release
- defer font-manager load to improve startup
- fix multi-window opening
- Update README.md
- Update README.md
- Update README.md
- add contenteditable preview & change default & remove window shadow
- change preview sentence
- add window shadow
- fix italic spelling
